### PR TITLE
ADD: require min typing version

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,3 +4,4 @@ pydantic==1.8.2
 pymongo==3.12.0
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
+typing>=3.10.0.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,4 +4,4 @@ pydantic==1.8.2
 pymongo==3.12.0
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
-typing>=3.10.0.2
+typing-extensions>=3.10.0.2


### PR DESCRIPTION
There was a bug in previous versions with `_GenericAlias`